### PR TITLE
Add syntax highlight for *.bemhtml.xjst

### DIFF
--- a/grammars/bemhtml.cson
+++ b/grammars/bemhtml.cson
@@ -1,6 +1,7 @@
 'comment': 'BEMHTML Syntax: based on javascript syntax v2.0'
 'fileTypes': [
     'bemhtml',
+    'bemhtml.xjst',
     'bemtree.xjst'
 ]
 'firstLineMatch': '^#!.*\\bnode'


### PR DESCRIPTION
Used in [enb-bemxjst](https://github.com/enb-bem/enb-bemxjst) package.
