### PR TITLE
Fix Typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ pull request to add snippets, make grammar tweaks, etc.
 
 ## Upgrade
 
-To upgrade pkg, reinstall with shell command `rm -rf bemhtml && apm instal bemhtml` in /Users/username/.atom/packages
+To upgrade pkg, reinstall with shell command `rm -rf bemhtml && apm install bemhtml` in /Users/username/.atom/packages
 
 ## Snippets
 **don't be afraid to press ⇥**


### PR DESCRIPTION
> reinstall with shell command `rm -rf bemhtml && apm instal bemhtml`

:s/instal/install

(missing an L)
